### PR TITLE
Add ruby submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "modules/ruby"]
+	path = modules/ruby
+	url = https://github.com/puppetlabs/puppetlabs-ruby.git

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,8 @@ Vagrant.configure(2) do |config|
   #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
   # end
 
-  config.vm.provision "puppet"
+  config.vm.provision "puppet" do |puppet|
+    puppet.module_path = "modules"
+  end
 
 end

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -4,6 +4,8 @@ class { 'ruby':
 }
 
 package { 'selenium-webdriver':
-  ensure => 'installed',
+  ensure   => 'installed',
   provider => 'gem',
 }
+
+Class['ruby'] -> Package <| provider == gem |>


### PR DESCRIPTION
To use the ruby class from puppetlabs you have to have that class
available locally, in this case under modules/ruby/manifests/init.pp
(which is the autoloaded location for the ruby class).

I added the puppetlabs-ruby repo as a submdoule in the module_path.

This means you must also specify a module_path in your vagrant file.

The final piece is,  since you need ruby-dev (the ruby class) to install
anything from the 'gem' provider, I made that dependency explicit in
default.pp.
